### PR TITLE
コロンを含むnpm scriptsがダッシュ(-)で置き換えることで実行できるように

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NPM_COMMANDS := access adduser audit bin bugs c cache ci cit completion config c
 
 .PHONY: $(NPM_SCRIPTS)
 $(NPM_SCRIPTS): %:
-	@$(DOCKER_WOWGIT) npm run $@
+	@echo $@ | sed 's/-/:/g' | xargs $(DOCKER_WOWGIT) npm run
 
 .PHONY: $(NPM_COMMANDS)
 $(NPM_COMMANDS): %:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "typeRoots" : [
-    "typings"
-  ],
+  "typeRoots": ["typings"],
   "compileOnSave": false,
   "compilerOptions": {
     "target": "esnext",


### PR DESCRIPTION
例
`npm run format:fix`は `make format-fix`で実行できる

Fixes #47 