### PR TITLE
カバレッジが取れていない問題を修正

### DIFF
--- a/client/containers/branchPane.tsx
+++ b/client/containers/branchPane.tsx
@@ -1,1 +1,3 @@
+import * as React from "react";
+
 export default () => <div>graphPane</div>;

--- a/client/containers/commitPane.tsx
+++ b/client/containers/commitPane.tsx
@@ -1,1 +1,3 @@
+import * as React from "react";
+
 export default () => <div>commitPane</div>;

--- a/client/containers/graphPane.tsx
+++ b/client/containers/graphPane.tsx
@@ -1,1 +1,3 @@
+import * as React from "react";
+
 export default () => <div>branchPane</div>;

--- a/client/containers/header.tsx
+++ b/client/containers/header.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import * as React from "react";
+
 import NavbarDropdown from "../components/navbarDropdown";
 
 export default () => (

--- a/client/layouts/main.tsx
+++ b/client/layouts/main.tsx
@@ -1,5 +1,9 @@
+import * as React from "react";
+
 import Header from "../containers/header";
-import style from "../styles/style.scss";
+
+/* tslint:disable */
+const style = require("../styles/style.scss");
 
 export default ({ children }) => (
   <div>

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import BranchPane from "../containers/branchPane";
 import CommitPane from "../containers/commitPane";
 import GraphPane from "../containers/graphPane";

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     }
   },
   "jest": {
+    "globals": {
+      "ts-jest": {
+        "enableTsDiagnostics": true
+      }
+    },
     "transform": {
       "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,12 @@
       "jsx",
       "json"
     ],
-    "testURL": "http://localhost/"
+    "testURL": "http://localhost/",
+    "collectCoverageFrom": [
+      "**/*.{ts,tsx}",
+      "!**/*.d.ts",
+      "!**/*.{test,spec}.{ts,tsx}"
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "jest": {
     "globals": {
       "ts-jest": {
-        "enableTsDiagnostics": true
+        "enableTsDiagnostics": true,
+        "skipBabel": true
       }
     },
     "transform": {

--- a/server/domain/status.ts
+++ b/server/domain/status.ts
@@ -1,3 +1,4 @@
+import File from "./file";
 /**
  * This class represents the status of a git repository
  */

--- a/server/interfaces/resolvers/root.test.ts
+++ b/server/interfaces/resolvers/root.test.ts
@@ -1,3 +1,5 @@
+import { IFieldResolver } from "graphql-tools";
+
 import StatusService from "../../app/status";
 import File from "../../domain/file";
 import GitService from "../../domain/git_service";
@@ -26,7 +28,8 @@ describe("Query", () => {
       const context = {
         statusService: new StatusService(new MockGitService())
       };
-      const status = await resolver.Query.status({}, args, context);
+      /* tslint:disable */
+      const status = await resolver.Query["status"]({}, args, context);
       expect(status.untracked).toHaveLength(1);
       expect(status.untracked[0].path).toBe("/path/to/untracked/file");
       expect(status.renamed).toHaveLength(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
-    "jsx": "preserve",
+    "jsx": "react",
     "allowJs": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
- [x]  jestでカバレッジを取る際は、`--coverage`に加えて対象ファイルをglobのリストで指定する必要があるので、package.jsonに指定しました。
- [x] ついでにテスト実行時に型チェックを行うようにしました。
- [x] masterのコードで型チェックが通らなかった箇所を修正
- [x] テストしたファイルのカバレッジだけが表示されない謎の現象が起きているので修正する。