### PR TITLE
tslintでPascalCaseの変数を許可

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,8 @@
       true,
       "ban-keywords",
       "check-format",
-      "allow-leading-underscore"
+      "allow-leading-underscore",
+      "allow-pascal-case"
     ]
   }
 }


### PR DESCRIPTION
Stateless Componentだとpascal case (キャメルケースかつ先頭文字が大文字　ex: PascalCase) の変数を使うことが多いが、tslintでは許可されていなかったため許可するようにしました。

例えば、
```tsx
// AppはStateless Component
const App = () => <div>hoge</div>
```
みたいなコードがあったとするとAppでtslintがエラーをはく。