### PR TITLE
For first developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ By default the server will run on port 3000.
 
 ### How to start development
 
+First time, type the following instead of `npm install`.
+(Usually, you can skip the next time.)
+
+```
+make install
+```
+
 To start development, type the following instead of `npm start`.
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Git web client that wows you
 
 ## Installation
 
-```
+```bash
 git clone https://github.com/superwower/wowgit.git
 cd wowgit
 make prod
@@ -24,13 +24,13 @@ By default the server will run on port 3000.
 First time, type the following instead of `npm install`.
 (Usually, you can skip the next time.)
 
-```
+```bash
 make install
 ```
 
 To start development, type the following instead of `npm start`.
 
-```
+```bash
 make dev
 ```
 


### PR DESCRIPTION
`git clone` した直後だと `make dev` が失敗するので手順を追加しました。

\# 普通は Installation で `make prod` するから `make install` は不要でしょうか?